### PR TITLE
add support for named global environments

### DIFF
--- a/zpy.plugin.zsh
+++ b/zpy.plugin.zsh
@@ -255,8 +255,9 @@ ZPY_PROCS=${${$(nproc 2>/dev/null):-$(sysctl -n hw.logicalcpu 2>/dev/null)}:-4}
     unset REPLY
     [[ $1 ]] || return
     rehash
-
-    if (( $+commands[md5sum] )) {
+    if [[ "${1:P}" == "${ZPY_VENVS_HOME}"* ]] {
+        REPLY="${${1:P}##*/}"
+    } elif (( $+commands[md5sum] )) {
         REPLY="${$(md5sum =(<<<${1:P}))%% *}"
     } else {
         REPLY="$(md5 -qs ${1:P})"
@@ -845,7 +846,12 @@ ZPY_PROCS=${${$(nproc 2>/dev/null):-$(sysctl -n hw.logicalcpu 2>/dev/null)}:-4}
     local REPLY vpath venv
     .zpy_venvs_path || return
     vpath=$REPLY
-    venv=$vpath/$1; shift      # chomp <venv-name>
+
+    if [[ "${REPLY}" == "${ZPY_VENVS_HOME}"* ]] {
+        venv="$vpath/${1/#venv/venv-${${REPLY}##*/}}"; shift      # chomp <venv-name>
+    } else {
+        venv=$vpath/$1; shift      # chomp <venv-name>
+    }
 
     local reqstxts=()          # chomp [-- <reqs-txt>...]:
     local cmd_end=${@[(I)--]}
@@ -967,6 +973,11 @@ ZPY_PROCS=${${$(nproc 2>/dev/null):-$(sysctl -n hw.logicalcpu 2>/dev/null)}:-4}
 
     local venv
     .zpy_venvs_path $projdir || return
+
+    if [[ "${REPLY}" == "${ZPY_VENVS_HOME}"* ]] {
+        venv_name="${venv_name/#venv/venv-${${REPLY}##*/}}"
+    }
+
     venv=$REPLY/$venv_name
 
     local activator=$venv/bin/activate


### PR DESCRIPTION
Hello, I've been using zpy as a package manager for myself, with some modifications to allow for creating and using named environments that are shared between projects (like in conda / virtualenv), so that the "venv" name is not a hash, but an actual name.

Sending this PR in case you like the modification and you think that's something you would like to be integrated in zpy.

Example of how I use it:

```bash
~/var/my-proj
❯ activate -i     ## manually select /Users/kimon/.local/share/venvs/g311

~/var/my-proj                                                                         (venv-g311) 2s
❯ which python
/Users/kimon/.local/share/venvs/g311/venv-g311/bin/python

~/var/my-proj                                                                         (venv-g311) 2s
❯ ...do project work here
```

... and in order to install shared libraries:

```bash
~/var/my-proj                                                                         (venv-g311)
❯ cd /Users/kimon/.local/share/venvs/g311

…/share/venvs/g311                                                                    (venv-g311)
❯ ls -l
total 24
lrwxr-xr-x   1 kimon  staff    36 Mar 12 16:19 project -> /Users/kimon/.local/share/venvs/g311
-rw-r--r--   1 kimon  staff  2858 Apr  5 03:30 requirements.in
-rw-r--r--   1 kimon  staff  5431 Apr  5 03:30 requirements.txt
drwxr-xr-x  12 kimon  staff   384 Mar 14 20:46 venv-g311

…/share/venvs/g311                                                                    (venv-g311)
❯ pipacs ...
```
